### PR TITLE
Add new guide on netCDF file format

### DIFF
--- a/docs/source/_static/data_management/file_formats/index.rst
+++ b/docs/source/_static/data_management/file_formats/index.rst
@@ -1,0 +1,8 @@
+File Formats
+============
+
+
+.. toctree::
+   :maxdepth: 1
+
+   netcdf.md

--- a/docs/source/_static/data_management/file_formats/netcdf.md
+++ b/docs/source/_static/data_management/file_formats/netcdf.md
@@ -2,14 +2,14 @@
 >**Warning**
 > This guide needs additional information
 
-NetCDF (Network Common Data Form), is a file format that stores data in arrays. Array values may be accessed directly,
-without knowing how the data are stored, and metadata information may be stored with the data.
+NetCDF (Network Common Data Form), is a file format that stores scientific data in arrays. Array values may be accessed
+directly, without knowing how the data are stored, and metadata information may be stored with the data.
 
 * Binary file format commonly used for scientific data
 * Self-describing, includes metadata
 * Multi-dimensional array data model
 
-#### Data Model (Essentials)
+The [netCDF data model](https://docs.unidata.ucar.edu/netcdf-c/current/netcdf_data_model.html) consists of the following:
 * variable
   * Multi-dimensional array
   * Column-oriented: each variable as a separate entity
@@ -24,8 +24,9 @@ without knowing how the data are stored, and metadata information may be stored 
 
 
 ## Purpose for this guideline
+NetCDF is a file format commonly used at LASP...
 
-#### Why Use NetCDF?
+Benefits of using netCDF:
 * Self-describing
   * structure captures coordinate system (functional relationship)
   * includes metadata
@@ -39,7 +40,7 @@ without knowing how the data are stored, and metadata information may be stored 
 * Open specification (unlike IDL save files)
 
 ## Options for this guideline
-
+There are two netCDF data models:
 * NetCDF-3 classic
 * NetCDF-4 built on HDF5
   * recommended but prefer classic constructs

--- a/docs/source/_static/data_management/file_formats/netcdf.md
+++ b/docs/source/_static/data_management/file_formats/netcdf.md
@@ -1,0 +1,107 @@
+# NetCDF
+>**Warning**
+> This guide needs additional information
+
+NetCDF (Network Common Data Form), is a file format that stores data in arrays. Array values may be accessed directly,
+without knowing how the data are stored, and metadata information may be stored with the data.
+
+* Binary file format commonly used for scientific data
+* Self-describing, includes metadata
+* Multi-dimensional array data model
+
+#### Data Model (Essentials)
+* variable
+  * Multi-dimensional array
+  * Column-oriented: each variable as a separate entity
+* dimension
+  * Usually temporal, spatial, spectral, ...
+  * Can be unlimited length. One, at most, is recommended for a growing time dimension
+* attribute
+  * Metadata: global and variable level
+* group
+  * Akin to directories
+  * Avoid unless you really need the complex structure
+
+
+## Purpose for this guideline
+
+#### Why Use NetCDF?
+* Self-describing
+  * structure captures coordinate system (functional relationship)
+  * includes metadata
+* Efficient storage
+  * packing
+  * compression
+* Efficient access
+  * chunking
+  * http byte range
+  * parallel IO
+* Open specification (unlike IDL save files)
+
+## Options for this guideline
+
+* NetCDF-3 classic
+* NetCDF-4 built on HDF5
+  * recommended but prefer classic constructs
+
+## How to apply this guideline
+
+#### NetCDF Files
+* Binary format with open specification
+* Requires software libraries to read and write C, Fortran, Java, python, IDL, ...
+* Internal compression, don't bother to compress NetCDF files externally
+* HTTP byte range requests
+* Parallel IO
+* nc file extension
+* Don't be afraid of big files
+
+#### Coordinate System
+* Dimensions should be used to define a coordinate system
+  * e.g. temporal, spatial, spectral
+  * Avoid using dimensions to group data
+  * Think "functional relationship". Each independent variable should represent a dimension.
+* coordinate variable
+  * 1D variable with dimension of the same name
+  * strictly monotonic (ordered)
+  * no missing values
+  * Independent variable of functional relationship
+  * Every dimension should have one
+* shared dimensions
+  * Each variable should reuse dimensions to indicate that they share the same coordinates (domain set)
+
+#### Time as Coordinate Variable
+* If the data are a function of a single time dimension then there should be a single time variable
+  * avoid breaking time up by date and time of day
+* Prefer numeric time units
+  * time unit since an epoch
+  * e.g. "seconds since 1970-01-01", "microseconds since 1980-01-06"
+
+#### Metadata
+* Optional but useful to make NetCDF file self-describing
+* attribute
+  * global (dataset level)
+    * title
+    * history (provenance)
+  * variable
+    * long_name
+    * units
+* Conventions
+  * Climate and Forecast (CF)
+  * Attribute Convention for Data Discovery (ACDD)
+  * udunits: standard units
+
+#### Other useful variable attributes
+* missing_value
+  * prefer over _FillValue
+  * NaN is a good option
+* valid_range, valid_min, valid_max
+* scale_factor, add_offset (packed values)
+* cell_methods: standards for representing data cells (bins)
+  * e.g. daily average, wavelength bins
+
+## Useful Links
+* [NetCDF User's Guide](https://docs.unidata.ucar.edu/nug/current/)
+* [NetCDF ToolsUI](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/toolsui_ref.html)
+
+
+Credit: Content taken from a Confluence guide written by Doug Lindholm

--- a/docs/source/_static/data_management/file_formats/netcdf.md
+++ b/docs/source/_static/data_management/file_formats/netcdf.md
@@ -86,9 +86,9 @@ without knowing how the data are stored, and metadata information may be stored 
     * long_name
     * units
 * Conventions
-  * Climate and Forecast (CF)
-  * Attribute Convention for Data Discovery (ACDD)
-  * udunits: standard units
+  * [Climate and Forecast (CF)](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html)
+  * [Attribute Convention for Data Discovery (ACDD)](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3)
+  * [udunits](https://www.unidata.ucar.edu/software/udunits/): standard units
 
 #### Other useful variable attributes
 * missing_value
@@ -96,7 +96,7 @@ without knowing how the data are stored, and metadata information may be stored 
   * NaN is a good option
 * valid_range, valid_min, valid_max
 * scale_factor, add_offset (packed values)
-* cell_methods: standards for representing data cells (bins)
+* [cell_methods](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#_data_representative_of_cells): standards for representing data cells (bins)
   * e.g. daily average, wavelength bins
 
 ## Useful Links

--- a/docs/source/_static/data_management/file_formats/netcdf.md
+++ b/docs/source/_static/data_management/file_formats/netcdf.md
@@ -23,10 +23,12 @@ The [netCDF data model](https://docs.unidata.ucar.edu/netcdf-c/current/netcdf_da
   * Avoid unless you really need the complex structure
 
 
-## Purpose for this guideline
-NetCDF is a file format commonly used at LASP...
+## Why use NetCDF
+NetCDF is a file format commonly used at LASP as it is the "highly preferred" format for NASA Earth Observing System
+Data and Information System data products, per their Data Product Development Guide for Data Producers.
+This affects all NASA Earth Science missions.
 
-Benefits of using netCDF:
+NetCDF features:
 * Self-describing
   * structure captures coordinate system (functional relationship)
   * includes metadata
@@ -39,13 +41,13 @@ Benefits of using netCDF:
   * parallel IO
 * Open specification (unlike IDL save files)
 
-## Options for this guideline
+## Options available
 There are two netCDF data models:
 * NetCDF-3 classic
 * NetCDF-4 built on HDF5
   * recommended but prefer classic constructs
 
-## How to apply this guideline
+## How to use this data format
 
 #### NetCDF Files
 * Binary format with open specification
@@ -92,9 +94,10 @@ There are two netCDF data models:
   * [udunits](https://www.unidata.ucar.edu/software/udunits/): standard units
 
 #### Other useful variable attributes
-* missing_value
-  * prefer over _FillValue
-  * NaN is a good option
+* _FillValue
+  * missing_value is considered deprecated and is not recommended by the NetCDF Users Group.
+  * NaN is another option, however, NaNs in files are handled differently in every language and so it may
+  be better to pick a value for official data products that many users will be using
 * valid_range, valid_min, valid_max
 * scale_factor, add_offset (packed values)
 * [cell_methods](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#_data_representative_of_cells): standards for representing data cells (bins)
@@ -103,6 +106,7 @@ There are two netCDF data models:
 ## Useful Links
 * [NetCDF User's Guide](https://docs.unidata.ucar.edu/nug/current/)
 * [NetCDF ToolsUI](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/toolsui_ref.html)
+* [NetCDF Workshop Materials](https://www.unidata.ucar.edu/software/netcdf/workshops/2011/index.html)
 
 
 Credit: Content taken from a Confluence guide written by Doug Lindholm

--- a/docs/source/_static/data_management/index.rst
+++ b/docs/source/_static/data_management/index.rst
@@ -1,0 +1,8 @@
+Data Management
+===============
+
+
+.. toctree::
+   :maxdepth: 1
+
+   file_formats/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,3 +7,4 @@ Welcome to the LASP Developer's Guide!
    :maxdepth: 1
 
    licensing
+   data_management/index


### PR DESCRIPTION
Created a guide about the netCDF file format pulling content written by Doug Lindholm. [Confluence page](https://confluence.lasp.colorado.edu/display/DS/NetCDF+Best+Practices)

The content is mostly in the structure of bullet points. Some additional text is needed to provide context and explain how this file format is being used at LASP. I added a warning at the top of the guide noting that it's incomplete. 

Details still needed:

- Expand overview section and explain bullet points
- Add a few sentences about the purpose of the guide
- Expand on options available
- Expand on how to apply the guide. Perhaps move the external links listed at the end of the guide to this section followed by tips and recommendations specific to LASP.
- Are there other useful links to add?


Credit is given to Doug at the bottom of the file, but we should figure out how best to do this since the structure is different from his original page