### PR TITLE
Increase width and center content in sphinx_rdt_theme

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,10 @@
+/* Increase the width of the content area */
+.wy-nav-content {
+    max-width: none;
+}
+
+/* Center the content */
+.wy-nav-content {
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,3 +35,8 @@ source_suffix = {
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
+
+
+# Add the custom CSS file to the list of stylesheets
+def setup(app):
+    app.add_css_file('css/custom.css')


### PR DESCRIPTION
This PR configures the `sphinx_rtd_theme` theme so that there is no `max-width` on the page.

Closes #30 