### PR TITLE
Add a guide on LASP GitHub organization

### DIFF
--- a/docs/source/workflows/open_source/index.rst
+++ b/docs/source/workflows/open_source/index.rst
@@ -6,3 +6,4 @@ Open Source
    :maxdepth: 1
 
    citing_software.md
+   lasp_github_org.md

--- a/docs/source/workflows/open_source/lasp_github_org.md
+++ b/docs/source/workflows/open_source/lasp_github_org.md
@@ -1,0 +1,59 @@
+# LASP GitHub Organization
+
+LASP has a public-facing Github organization, which can be used as an umbrella source for any open source repositories under LASP. We prefer to keep open source projects under a general LASP umbrella where it makes sense, so this project is not restricted to specific projects or maturity. However, projects under this heading do need to follow a few rules.
+
+### General Guidelines
+All repositories and maintainers should abide by the following rules:
+
+1. Repositories must have at least one admin maintainer who actively works at LASP
+2. Repositories and contributors should follow the code of [Code of Conduct](https://github.com/lasp/repository-template/blob/main/CODE_OF_CONDUCT.md)
+3. Repositories must include a license and a README.md
+4. Repository names should be clear, specific, and unique within the organization
+
+### GitHub Organization Maintainers
+The Github at LASP Open Source Stewards (GLOSS) is a committee of volunteers committed to helping those at LASP with open source project management. This committee consists of volunteers that have agreed to answer questions, set up Github repositories within the LASP organization, and support open source projects within LASP.
+
+#### GLOSS Requirements
+* Assist with answering questions in slack or via email about open source project management, open source tools, and the LASP Github organization
+* Members should be experienced with Github project management
+* Create open source projects under the [LASP Github Organization](https://github.com/lasp)
+* Help ensure all projects follow the guidelines laid out in the LASP Github Organization rules
+* Help ensure all projects and maintainers follow the LASP open source [Code of Conduct](https://github.com/lasp/repository-template/blob/main/CODE_OF_CONDUCT.md)
+
+
+#### Current Members:
+* Maxine Hartnett
+* Keira Brooks
+* Matthew Bourque
+* Rita Borelli
+
+If you are interested in joining GLOSS, please reach out to the #open-source slack channel or email a current maintainer.
+
+## How to create a repository under the LASP GitHub Organization
+To create a repository within the organization, you must send a message to the slack channel #open-source or email one of the maintainers with the following information:
+
+1. Repository name
+2. Initial maintainer(s)
+3. Repository description
+
+By default, repositories are expected to be public. If you want to create a private repo, please reach out for an exception. Repositories will be created with the LASP [template](https://github.com/lasp/repository-template).
+
+### Repository Requirements
+All repositories are required to contain the following files:
+
+* License
+  * This license must be an MIT license with a copyright to the University of Colorado as follows:
+  * Copyright (c) 202x The Regents of the University of Colorado
+* README.md
+  * This should include a basic description of your project at minimum, although we also encourage installation notes, a user guide, contributor guide, and any other information that someone using your project would want to know.
+
+Beyond those requirements, repository management is up to the individual. However, the #open-source channel is available for anyone with questions about best practices, repository management, releasing projects, or anything related to open source development.
+
+
+## Acronyms
+List of acronyms used in the guide
+
+* **GLOSS** = Github at LASP Open Source Stewards
+
+
+Credit: Content taken from a Confluence guide written by Maxine Hartnett


### PR DESCRIPTION
Created a guide on the LASP GitHub organization and how to create a repository under this organization. 

Used content from two related confluence pages to create this guide:

- https://confluence.lasp.colorado.edu/display/DS/LASP+Github+Organization

- https://confluence.lasp.colorado.edu/pages/viewpage.action?pageId=166666430