### PR TITLE
Updated version numbers for v1.0.0 release

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = 'developer-guide'
 copyright = '2024, Regents of the University of Colorado'
 author = 'Matthew Bourque, Keira Brooks, Luke Charbonneau, Matthew Maclay, Veronica Martinez, Alex Ware'
-release = '0.1.0'
+release = '1.0.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "developer-guide"
-version = "0.1.0"
+version = "1.0.0"
 description = "Guidelines for software developers at LASP"
 authors = [
     {name = "Matthew Bourque", email = "Matthew.Bourque@lasp.colorado.edu>"},


### PR DESCRIPTION
This PR updates version numbers to mark the `v1.0.0` release.