### PR TITLE
Add a PR template with a checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@ Include a ticket number and link to the issue this pull request addresses (if ap
 
 - [ ] Did you update the index.rst to show your page in the table of contents?
 - [ ] Did you remove any internal LASP resources, links, keys, or sensitive information?
-- [ ] Did you ensure your contribution is general and not user or case specific?
+- [ ] Did you ensure your contribution is general and not user- or case-specific?
 - [ ] Does your code follow the style guidelines of this project?
 - [ ] Did you perform a self-review of your code (including a rendered check for visible formatting issues)?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Change Summary
+
+Please include a description of the change.
+
+## Issue ticket number
+
+Include a ticket number and link to the issue this pull request addresses (if applicable).
+
+## Checklist before requesting a review
+
+- [ ] Did you update the index.rst to show your page in the table of contents?
+- [ ] Did you remove any internal LASP resources, links, keys, or sensitive information?
+- [ ] Did you ensure your contribution is general and not user or case specific?
+- [ ] Does your code follow the style guidelines of this project?
+- [ ] Did you perform a self-review of your code (including a rendered check for visible formatting issues)?


### PR DESCRIPTION
This PR adds a new pull request template to the repository to standardize PRs. It includes sections for a change summary, issue ticket number, and a checklist to ensure requirements are met and best practices are followed before review.

Closes #77 